### PR TITLE
Message recording

### DIFF
--- a/AzureEngine/AzureEngine.cs
+++ b/AzureEngine/AzureEngine.cs
@@ -66,6 +66,25 @@ namespace AzureEngine
             }
         }
 
+        public async Task DownloadFile(String filePath, String fileName, String downloadFile)
+        {
+            String fullFile = filePath + fileName;
+
+            try
+            {
+                CloudBlockBlob blobBlock = blobContainer.GetBlockBlobReference(downloadFile);
+
+                Console.WriteLine("Downloading blob file to " + fullFile + ". Started at " + DateTime.Now);
+                await blobBlock.DownloadToFileAsync(fullFile, System.IO.FileMode.Create);
+                Console.WriteLine("File downloaded. Finished at " + DateTime.Now);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("An error occurred. Details are below");
+                Console.WriteLine(e.ToString());
+            }
+        }
+
         public async Task DeleteBlob()
         {
             if (blobContainer == null) return;

--- a/AzureEngine/AzureEngine.csproj
+++ b/AzureEngine/AzureEngine.csproj
@@ -64,6 +64,7 @@
     <Compile Include="AzureEngine.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SystemMessage.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/AzureEngine/AzureEngine.csproj
+++ b/AzureEngine/AzureEngine.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SystemMessage.cs" />
+    <Compile Include="SystemMessageContainer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/AzureEngine/Program.cs
+++ b/AzureEngine/Program.cs
@@ -14,22 +14,36 @@ namespace AzureEngine
             p.Run();
         }
 
+        SystemMessageContainer systemMessages;
+
         public async void Run()
         {
-            AzureEngine ae = new AzureEngine();
+            systemMessages = new SystemMessageContainer();
+            systemMessages.MessagesUpdated += SystemMessages_MessagesUpdated;
+            AzureEngine ae = new AzureEngine(systemMessages);
             ae.InitStorage();
             Console.WriteLine("Press any key to upload the test file");
             Console.ReadLine();
             ae.SendFile(@"C:\Users\fgreenro\Documents\Repo Code\Test Files & Scripts\", "AzureTest.txt").GetAwaiter().GetResult();
-            Console.WriteLine("Press any key to download the test file");
-            Console.ReadLine();
-            ae.DownloadFile(@"C:\Users\fgreenro\Documents\Repo Code\Test Files & Scripts\", "AzureDownload.txt", "AzureTest.txt").GetAwaiter().GetResult();
+            Console.WriteLine("Press the D key to download the test file. Press any other key to skip");
+            if(Console.ReadLine().ToUpper() == "D")
+                ae.DownloadFile(@"C:\Users\fgreenro\Documents\Repo Code\Test Files & Scripts\", "AzureDownload.txt", "AzureTest.txt").GetAwaiter().GetResult();
             Console.WriteLine("Press any key to delete the blob");
             Console.ReadLine();
             ae.DeleteBlob().GetAwaiter().GetResult();
 
             Console.WriteLine("Press any key to exit...");
             Console.ReadLine();
+        }
+
+        private void SystemMessages_MessagesUpdated(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+        {
+            SystemMessage sm = systemMessages.GetLatestMessage();
+            Console.WriteLine(sm.TimeStamp + ": " + sm.GetType() + sm.Message);
+            if (sm.Type == SystemMessage.MessageType.Error)
+                Console.WriteLine(sm.ErrorDetails);
+
+            Console.WriteLine();
         }
     }
 }

--- a/AzureEngine/Program.cs
+++ b/AzureEngine/Program.cs
@@ -20,7 +20,10 @@ namespace AzureEngine
             ae.InitStorage();
             Console.WriteLine("Press any key to upload the test file");
             Console.ReadLine();
-            ae.SendFile(@"C:\Users\fgreenro\Documents\Repo Code\Test Files & Scripts\", "AzureTest2.txt").GetAwaiter().GetResult();
+            ae.SendFile(@"C:\Users\fgreenro\Documents\Repo Code\Test Files & Scripts\", "AzureTest.txt").GetAwaiter().GetResult();
+            Console.WriteLine("Press any key to download the test file");
+            Console.ReadLine();
+            ae.DownloadFile(@"C:\Users\fgreenro\Documents\Repo Code\Test Files & Scripts\", "AzureDownload.txt", "AzureTest.txt").GetAwaiter().GetResult();
             Console.WriteLine("Press any key to delete the blob");
             Console.ReadLine();
             ae.DeleteBlob().GetAwaiter().GetResult();

--- a/AzureEngine/SystemMessage.cs
+++ b/AzureEngine/SystemMessage.cs
@@ -99,5 +99,26 @@ namespace AzureEngine
             set { errorDetails = value; }
         }
         #endregion
+
+        #region Functions
+        public String GetType()
+        {
+            switch(messageType)
+            {
+                case MessageType.Unknown:
+                    return "";
+                case MessageType.Status:
+                    return "Status - ";
+                case MessageType.Information:
+                    return "Information - ";
+                case MessageType.Warning:
+                    return "WARNING - ";
+                case MessageType.Error:
+                    return "ERROR - ";
+                default:
+                    return "";
+            }
+        }
+        #endregion
     }
 }

--- a/AzureEngine/SystemMessage.cs
+++ b/AzureEngine/SystemMessage.cs
@@ -1,0 +1,103 @@
+﻿/*
+ * This class is for the structure of messages raised by the AzureEngine.
+ * These could include messages relating to the status of operations, or warning and error messages
+ * Author: F. Greenroyd
+ * Date: 2018-06-20 
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AzureEngine
+{
+    public class SystemMessage
+    {
+        #region Enums
+        public enum MessageType { Unknown, Status, Information, Warning, Error };
+        #endregion
+
+        #region Variables
+        private DateTime messageTimeStamp;
+        private String message;
+        private MessageType messageType;
+        private String errorDetails; //Not used in all messages - will be used when throwing exceptions mostly for Debug and Reporting purposes
+        #endregion
+
+        #region Constructors
+        /// <summary>
+        /// Empty constructor with a new message instance
+        /// </summary>
+        public SystemMessage()
+        {
+            message = "";
+            messageType = MessageType.Unknown;
+            messageTimeStamp = DateTime.Now;
+        }
+
+        /// <summary>
+        /// Create a new system message instance with a message to display to the user
+        /// </summary>
+        /// <param name="message">String - the message to display to the user</param>
+        public SystemMessage(String message)
+        {
+            this.message = message;
+            messageType = MessageType.Unknown;
+            messageTimeStamp = DateTime.Now;
+        }
+
+        /// <summary>
+        /// Create a new system message instance of a specified type
+        /// </summary>
+        /// <param name="message">String - the message to display to the user</param>
+        /// <param name="type">Enum - what type of message is this? Options: Status, Information, Warning, Error</param>
+        public SystemMessage(String message, MessageType type)
+        {
+            this.message = message;
+            messageType = type;
+            messageTimeStamp = DateTime.Now;
+        }
+
+        /// <summary>
+        /// Create a new system message instance of a specified type
+        /// </summary>
+        /// <param name="message">String - the message to display to the user</param>
+        /// <param name="type">Enum - what type of message is this? Options: Status, Information, Warning, Error</param>
+        /// <param name="errorDetails">String - additional error details to display to the user</param>
+        public SystemMessage(String message, MessageType type, String errorDetails)
+        {
+            this.message = message;
+            messageType = type;
+            messageTimeStamp = DateTime.Now;
+            this.errorDetails = errorDetails;
+        }
+        #endregion
+
+        #region Properties
+        public DateTime TimeStamp
+        {
+            get { return messageTimeStamp; } //Read only property - no option to set the DateTime
+        }
+
+        public String Message
+        {
+            get { return message; }
+            set { message = value; }
+        }
+
+        public MessageType Type
+        {
+            get { return messageType; }
+            set { messageType = value; }
+        }
+
+        public String ErrorDetails
+        {
+            get { return errorDetails; }
+            set { errorDetails = value; }
+        }
+        #endregion
+    }
+}

--- a/AzureEngine/SystemMessageContainer.cs
+++ b/AzureEngine/SystemMessageContainer.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using System.ComponentModel; //For the INotifyProperty Interface
+using System.Runtime.CompilerServices; //For the CallerMemberName
+
+namespace AzureEngine
+{
+    public class SystemMessageContainer : INotifyPropertyChanged
+    {
+        #region Variables
+        public event PropertyChangedEventHandler PropertyChanged;
+        public event PropertyChangedEventHandler MessagesUpdated;
+
+        private List<SystemMessage> messages;
+        #endregion
+
+        #region Constructors
+        public SystemMessageContainer()
+        {
+            messages = new List<SystemMessage>();
+        }
+        #endregion
+
+        #region Functions
+        public void AddMessage(String message)
+        {
+            messages.Add(new SystemMessage(message));
+            NotifyMessagesChanged();
+        }
+
+        public void AddMessage(String message, SystemMessage.MessageType type)
+        {
+            messages.Add(new SystemMessage(message, type));
+            NotifyMessagesChanged();
+        }
+
+        public void AddMessage(String message, SystemMessage.MessageType type, String errorDetails)
+        {
+            messages.Add(new SystemMessage(message, type, errorDetails));
+            NotifyMessagesChanged();
+        }
+
+        public void AddInformationMessage(String message)
+        {
+            AddMessage(message, SystemMessage.MessageType.Information);
+        }
+
+        public void AddWarningMessage(String message)
+        {
+            AddMessage(message, SystemMessage.MessageType.Warning);
+        }
+
+        public void AddErrorMessage(String message)
+        {
+            AddMessage(message, SystemMessage.MessageType.Error);
+        }
+
+        public void AddErrorMessage(String message, String errorDetails)
+        {
+            AddMessage(message, SystemMessage.MessageType.Error, errorDetails);
+        }
+        #endregion
+
+        #region Events
+        private void NotifyMessagesChanged([CallerMemberName] String propertyName = "")
+        {
+            if (MessagesUpdated != null)
+                MessagesUpdated(this, new PropertyChangedEventArgs(propertyName));
+        }
+        #endregion
+    }
+}

--- a/AzureEngine/SystemMessageContainer.cs
+++ b/AzureEngine/SystemMessageContainer.cs
@@ -26,22 +26,27 @@ namespace AzureEngine
         #endregion
 
         #region Functions
-        public void AddMessage(String message)
+        private void AddMessage(String message)
         {
             messages.Add(new SystemMessage(message));
             NotifyMessagesChanged();
         }
 
-        public void AddMessage(String message, SystemMessage.MessageType type)
+        private void AddMessage(String message, SystemMessage.MessageType type)
         {
             messages.Add(new SystemMessage(message, type));
             NotifyMessagesChanged();
         }
 
-        public void AddMessage(String message, SystemMessage.MessageType type, String errorDetails)
+        private void AddMessage(String message, SystemMessage.MessageType type, String errorDetails)
         {
             messages.Add(new SystemMessage(message, type, errorDetails));
             NotifyMessagesChanged();
+        }
+
+        public void AddStatusMessage(String message)
+        {
+            AddMessage(message, SystemMessage.MessageType.Status);
         }
 
         public void AddInformationMessage(String message)
@@ -62,6 +67,11 @@ namespace AzureEngine
         public void AddErrorMessage(String message, String errorDetails)
         {
             AddMessage(message, SystemMessage.MessageType.Error, errorDetails);
+        }
+
+        public SystemMessage GetLatestMessage()
+        {
+            return messages.Last();
         }
         #endregion
 


### PR DESCRIPTION
Built in message recording for our AzureEngine.

This works by having a container of messages that the AzureEngine can add to. Different UIs can then listen into the container to find out when a message has been added to display to the user.

Different message types exist depending on what the system wants to display.
Status - new status information
Information - generic message
Warning - something might be wrong, but it won't break
Error - something did break

This was branched from the download PR - so review them in the order of creation to prevent conflicts.